### PR TITLE
[REFACTOR] [CONFIG] [DOCKER] docker-compose calls replaced by new "do…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ NPM_UPDATABLE_MODULES = $(shell npm outdated | cut -d' ' -f 1 | sed '1d' | xargs
 # DOCKER
 BUILDKIT_PROGRESS=plain
 DOCKER_BUILDKIT=1
+DOCKER_COMPOSE=docker compose
 
 .MAIN: test
 .PHONY: all clean dependencies help list test outdated


### PR DESCRIPTION
…cker compose".

- Command not found: docker-compose after docker 4.32.0 update: https://stackoverflow.com/a/78788716/6366150