### PR TITLE
Bump node from 22.10.0-alpine3.20 to 23.0.0-alpine3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-FROM node:22.10.0-alpine3.20 AS base
+FROM node:23.0.0-alpine3.20 AS base
 
 RUN  apk add --update --no-cache make \
   && apk upgrade --update --no-cache openssl libcrypto3 libssl3 # FIX CVE-2024-5535


### PR DESCRIPTION
Bumps node from 22.10.0-alpine3.20 to 23.0.0-alpine3.20.

---
updated-dependencies:
- dependency-name: node dependency-type: direct:production update-type: version-update:semver-major ...