### PR TITLE
[BUGFIX] SonarQube: Use `new Array()` instead of `Array()`.

### DIFF
--- a/src/hackerrank/interview_preparation_kit/arrays/cruch_bruteforce.js
+++ b/src/hackerrank/interview_preparation_kit/arrays/cruch_bruteforce.js
@@ -8,7 +8,7 @@ import { logger as console } from '../../../logger.js';
 function arrayManipulation(n, queries) {
   const LENGTH = n + 1;
   const SURROGATE_VALUE = 0;
-  const result = Array(LENGTH).fill(SURROGATE_VALUE);
+  const result = new Array(LENGTH).fill(SURROGATE_VALUE);
   let maximum = 0;
 
   for (const query of queries) {

--- a/src/hackerrank/interview_preparation_kit/arrays/cruch_optimized.js
+++ b/src/hackerrank/interview_preparation_kit/arrays/cruch_optimized.js
@@ -8,7 +8,7 @@ function arrayManipulation(n, queries) {
   //   last slot for storing accumSum result
   const LENGTH = n + 2;
   const INITIAL_VALUE = 0;
-  const result = Array(LENGTH).fill(INITIAL_VALUE);
+  const result = new Array(LENGTH).fill(INITIAL_VALUE);
   let maximum = 0;
 
   for (const query of queries) {

--- a/src/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/sherlock_and_anagrams.js
+++ b/src/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/sherlock_and_anagrams.js
@@ -6,7 +6,7 @@
 import { logger as console } from '../../../logger.js';
 
 function extraLongFactorials(n) {
-  const rs = [...Array(n)].reduce((a, b, i) => a * BigInt(i + 1), 1n);
+  const rs = [...new Array(n)].reduce((a, b, i) => a * BigInt(i + 1), 1n);
   return rs;
 }
 

--- a/src/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/sherlock_and_anagrams.js
+++ b/src/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/sherlock_and_anagrams.js
@@ -6,7 +6,7 @@
 import { logger as console } from '../../../logger.js';
 
 function extraLongFactorials(n) {
-  const rs = [...new Array(n)].reduce((a, b, i) => a * BigInt(i + 1), 1n);
+  const rs = new Array(n).fill().reduce((a, b, i) => a * BigInt(i + 1), 1n);
   return rs;
 }
 


### PR DESCRIPTION
Built-in constructors should be called consistently with or without "new" javascript:S7723